### PR TITLE
feat: Integrate ViewModels for Login and Register screens with Hilt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias { libs.plugins.kotlin.serialization }
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -53,6 +55,11 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.kotlinx.serialization.json)
+    // Hilt
+    implementation(libs.dagger.hilt.android)
+    ksp(libs.dagger.hilt.compiler)
+    implementation(libs.hilt.navigation.compose)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/launchcamera/MainActivity.kt
+++ b/app/src/main/java/com/example/launchcamera/MainActivity.kt
@@ -6,7 +6,9 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.example.launchcamera.screen.Navigation
 import com.example.launchcamera.ui.theme.LaunchCameraTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/launchcamera/MainApplication.kt
+++ b/app/src/main/java/com/example/launchcamera/MainApplication.kt
@@ -1,0 +1,7 @@
+package com.example.launchcamera
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class MainApplication: Application()

--- a/app/src/main/java/com/example/launchcamera/screen/LoginScreen.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/LoginScreen.kt
@@ -2,11 +2,22 @@ package com.example.launchcamera.screen
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import com.example.launchcamera.screen.util.ButtonPrimary
@@ -14,15 +25,20 @@ import com.example.launchcamera.screen.util.ButtonSecondary
 import com.example.launchcamera.screen.util.TextContent
 import com.example.launchcamera.screen.util.TextFieldCommon
 import com.example.launchcamera.screen.util.TextTitle
+import com.example.launchcamera.screen.viewModel.LoginViewModel
+import com.example.launchcamera.ui.theme.Purple40
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object LoginScreenKey: NavKey
+data object LoginScreenKey : NavKey
+
 private const val LOGIN_TITLE = "Sign In to account"
-private const val LOGIN_DESCRIPTION = "Sign in with your email and password for continue"
+private const val LOGIN_DESCRIPTION =
+    "Enter your ID and select whether you want us to save your session"
 
 @Composable
 fun LoginScreen(
+    viewModel: LoginViewModel,
     onLoginClicked: () -> Unit,
     onRegisterClicked: () -> Unit
 ) {
@@ -48,9 +64,9 @@ fun LoginScreen(
                     end = 32.dp
                 )
         )
-        TextInputUsername()
-        TextInputPassword()
-        ButtonLogin(onLoginClicked)
+        TextInputUsername(viewModel)
+        SwitchSaveSession(viewModel)
+        ButtonLogin(viewModel, onLoginClicked)
         ButtonLoginRegister(onRegisterClicked)
     }
 }
@@ -72,40 +88,81 @@ private fun DescriptionScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun TextInputUsername() {
+private fun TextInputUsername(viewModel: LoginViewModel) {
+    val id = viewModel.id.collectAsState()
+    val idError = viewModel.idError.collectAsState()
     TextFieldCommon(
-        value = "",
-        onValueChange = {},
-        label = { Text(text = "User name") },
+        value = id.value,
+        onValueChange = { viewModel.onIdChanged(it) },
+        label = { Text(text = "Enter your Id") },
         modifier = Modifier
             .padding(
                 bottom = 8.dp,
                 start = 32.dp,
                 end = 32.dp
-            )
+            ),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        isError = idError.value != null,
+        errorMessage = idError.value
     )
 }
 
 @Composable
-private fun TextInputPassword() {
-    TextFieldCommon(
-        value = "",
-        onValueChange = {},
-        label = { Text(text = "Password") },
+private fun SwitchSaveSession(viewModel: LoginViewModel) {
+    Row(
         modifier = Modifier
             .padding(
+                top = 16.dp,
                 bottom = 16.dp,
                 start = 32.dp,
                 end = 32.dp
             )
-    )
+            .fillMaxWidth()
+    ) {
+        val checked = viewModel.saveSession.collectAsState().value
+        Switch(
+            checked = checked,
+            onCheckedChange = {
+                viewModel.onSaveSessionChanged(it)
+            },
+            colors = SwitchDefaults.colors(
+                checkedTrackColor = Purple40
+            ),
+            thumbContent = if (checked) {
+                {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = "Checked",
+                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                    )
+                }
+            } else {
+                null
+            }
+        )
+
+        TextContent(
+            content = "Save session?",
+            modifier = Modifier
+                .weight(1f)
+                .padding(
+                    start = 8.dp,
+                    end = 8.dp
+                )
+                .padding(top = 12.dp)
+        )
+    }
 }
 
 @Composable
-private fun ButtonLogin(onLoginClicked: () -> Unit) {
+private fun ButtonLogin(viewModel: LoginViewModel, onLoginClicked: () -> Unit) {
     ButtonPrimary(
         text = "Login",
-        onClick = { onLoginClicked() },
+        onClick = {
+            if (viewModel.validateId()) {
+                onLoginClicked()
+            }
+        },
         modifier = Modifier
             .padding(
                 bottom = 8.dp,

--- a/app/src/main/java/com/example/launchcamera/screen/Navigation.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/Navigation.kt
@@ -1,10 +1,13 @@
 package com.example.launchcamera.screen
 
 import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
+import com.example.launchcamera.screen.viewModel.LoginViewModel
+import com.example.launchcamera.screen.viewModel.RegisterViewModel
 
 @Composable
 fun Navigation() {
@@ -13,7 +16,9 @@ fun Navigation() {
         backStack = backStack,
         entryProvider = entryProvider {
             entry<LoginScreenKey> {
+                val loginViewModel: LoginViewModel = hiltViewModel()
                 LoginScreen(
+                    viewModel = loginViewModel,
                     onLoginClicked = {
                         backStack.clear()
                         backStack.add(ProfileScreenKey)
@@ -29,7 +34,10 @@ fun Navigation() {
                 }
             }
             entry<RegisterScreenKey> {
-                RegisterScreen {
+                val registerViewModel: RegisterViewModel = hiltViewModel()
+                RegisterScreen(
+                    viewModel = registerViewModel
+                ) {
                     backStack.clear()
                     backStack.add(LoginScreenKey)
                 }

--- a/app/src/main/java/com/example/launchcamera/screen/RegisterScreen.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/RegisterScreen.kt
@@ -1,20 +1,22 @@
 package com.example.launchcamera.screen
 
-import android.media.AudioProfile
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import com.example.launchcamera.screen.util.ButtonPrimary
 import com.example.launchcamera.screen.util.TextContent
 import com.example.launchcamera.screen.util.TextFieldCommon
 import com.example.launchcamera.screen.util.TextTitle
+import com.example.launchcamera.screen.viewModel.RegisterViewModel
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -24,7 +26,7 @@ private const val TITLE_REGISTER = "Hi %s !"
 private const val DESCRIPTION_REGISTER = "Enter the data to complete the registration."
 
 @Composable
-fun RegisterScreen(onNavProfile: () -> Unit) {
+fun RegisterScreen(viewModel: RegisterViewModel, onNavProfile: () -> Unit) {
     val name = "David Martinez"
     Column(
         verticalArrangement = Arrangement.Center,
@@ -32,10 +34,10 @@ fun RegisterScreen(onNavProfile: () -> Unit) {
     ) {
         name.TitleRegister()
         DescriptionRegister()
-        TextFieldEmailRegister()
-        TextConfirmEmailRegister()
-        TextFieldPasswordRegister()
-        ButtonRegister(onNavProfile)
+        TextFieldEmailRegister(viewModel)
+        TextConfirmEmailRegister(viewModel)
+        TextFieldPhoneRegister(viewModel)
+        ButtonRegister(viewModel, onNavProfile)
     }
 }
 
@@ -65,55 +67,74 @@ private fun DescriptionRegister() {
 }
 
 @Composable
-private fun TextFieldEmailRegister() {
+private fun TextFieldEmailRegister(viewModel: RegisterViewModel) {
+    val email = viewModel.email.collectAsState()
+    val isErrorEmail = viewModel.errorEmail.collectAsState()
     TextFieldCommon(
-        value = "",
-        onValueChange = {},
+        value = email.value,
+        onValueChange = { viewModel.onEmailChanged(it) },
         label = { Text(text = "Email") },
         modifier = Modifier
             .padding(
                 bottom = 8.dp,
                 start = 32.dp,
                 end = 32.dp
-            )
+            ),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+        isError = isErrorEmail.value != null,
+        errorMessage = isErrorEmail.value
     )
 }
 
 @Composable
-private fun TextConfirmEmailRegister() {
+private fun TextConfirmEmailRegister(viewModel: RegisterViewModel) {
+    val confirmEmail = viewModel.confirmEmail.collectAsState()
+    val isErrorConfirmEmail = viewModel.errorConfirmEmail.collectAsState()
     TextFieldCommon(
-        value = "",
-        onValueChange = {},
+        value = confirmEmail.value,
+        onValueChange = { viewModel.onConfirmEmailChanged(it) },
         label = { Text(text = "Confirm Email") },
         modifier = Modifier
             .padding(
                 bottom = 8.dp,
                 start = 32.dp,
                 end = 32.dp
-            )
+            ),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+        isError = isErrorConfirmEmail.value != null,
+        errorMessage = isErrorConfirmEmail.value
     )
 }
 
 @Composable
-private fun TextFieldPasswordRegister() {
+private fun TextFieldPhoneRegister(viewModel: RegisterViewModel) {
+    val phone = viewModel.phone.collectAsState()
+    val isPhoneError = viewModel.errorPhone.collectAsState()
     TextFieldCommon(
-        value = "",
-        onValueChange = {},
-        label = { Text(text = "Password") },
+        value = phone.value,
+        onValueChange = { viewModel.onPhoneChanged(it) },
+        label = { Text(text = "Phone number") },
         modifier = Modifier
             .padding(
                 bottom = 16.dp,
                 start = 32.dp,
                 end = 32.dp
-            )
+            ),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        isError = isPhoneError.value != null,
+        errorMessage = isPhoneError.value
     )
 }
 
 @Composable
-private fun ButtonRegister(onNavProfile: () -> Unit) {
+private fun ButtonRegister(viewModel: RegisterViewModel, onNavProfile: () -> Unit) {
     ButtonPrimary(
         text = "Register",
-        onClick = { onNavProfile() },
+        onClick = {
+            if (viewModel.validateFields()) {
+                onNavProfile()
+            }
+        },
         modifier = Modifier
             .padding(
                 start = 32.dp,

--- a/app/src/main/java/com/example/launchcamera/screen/util/TextFieldCommon.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/util/TextFieldCommon.kt
@@ -1,7 +1,9 @@
 package com.example.launchcamera.screen.util
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
@@ -10,13 +12,23 @@ fun TextFieldCommon(
     value: String,
     onValueChange: (String) -> Unit,
     label: @Composable () -> Unit,
-    modifier: Modifier
+    isError: Boolean = false,
+    errorMessage: String? = null,
+    modifier: Modifier,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default
 ) {
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         label = label,
         modifier = modifier
-            .fillMaxWidth()
+            .fillMaxWidth(),
+        keyboardOptions = keyboardOptions,
+        isError = isError,
+        supportingText = {
+            if (isError && errorMessage != null) {
+                Text(text = errorMessage)
+            }
+        }
     )
 }

--- a/app/src/main/java/com/example/launchcamera/screen/viewModel/LoginVewModel.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/viewModel/LoginVewModel.kt
@@ -1,0 +1,42 @@
+package com.example.launchcamera.screen.viewModel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(): ViewModel() {
+
+    private val _id = MutableStateFlow("")
+    val id = _id.asStateFlow()
+
+    private val _idError = MutableStateFlow<String?>(null)
+    val idError = _idError.asStateFlow()
+
+    private val _saveSession = MutableStateFlow(true)
+    val saveSession = _saveSession.asStateFlow()
+
+    fun onIdChanged(newId: String) {
+        _id.update { newId }
+        if (newId.isNotBlank()) {
+            _idError.value = null
+        }
+    }
+
+    fun onSaveSessionChanged(save: Boolean) {
+        _saveSession.value = save
+    }
+
+    fun validateId(): Boolean {
+        return if (id.value.isNotBlank()) {
+            _idError.value = null
+            true
+        } else {
+            _idError.value = "ID cannot be empty"
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/example/launchcamera/screen/viewModel/RegisterViewModel.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/viewModel/RegisterViewModel.kt
@@ -1,0 +1,97 @@
+package com.example.launchcamera.screen.viewModel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.util.regex.Pattern
+import javax.inject.Inject
+
+@HiltViewModel
+class RegisterViewModel @Inject constructor(): ViewModel() {
+
+    private val _email = MutableStateFlow(EMPTY_STRING)
+    val email = _email.asStateFlow()
+
+    private val _errorEmail = MutableStateFlow<String?>(null)
+    val errorEmail = _errorEmail.asStateFlow()
+
+    private val _confirmEmail = MutableStateFlow(EMPTY_STRING)
+    val confirmEmail = _confirmEmail.asStateFlow()
+
+    private val _errorConfirmEmail = MutableStateFlow<String?>(null)
+    val errorConfirmEmail = _errorConfirmEmail.asStateFlow()
+
+    private val _phone = MutableStateFlow(EMPTY_STRING)
+    val phone = _phone.asStateFlow()
+
+    private val _errorPhone = MutableStateFlow<String?>(null)
+    val errorPhone = _errorPhone.asStateFlow()
+
+    fun onEmailChanged(newEmail: String) {
+        _email.update { newEmail }
+        if (newEmail.isNotBlank()) {
+            _errorEmail.value = null
+        }
+    }
+
+    fun onConfirmEmailChanged(newConfirmEmail: String) {
+        _confirmEmail.update { newConfirmEmail }
+        if (newConfirmEmail.isNotBlank()) {
+            _errorConfirmEmail.value = null
+        }
+    }
+
+    fun onPhoneChanged(newPhone: String) {
+        _phone.update { newPhone }
+        if (newPhone.isNotBlank()) {
+            _errorPhone.value = null
+        }
+    }
+
+    fun validateFields(): Boolean {
+        val emailPattern = Pattern.compile(REGEX_EMAIL)
+        val emailMatcher = emailPattern.matcher(email.value)
+
+        var isValid = true
+
+        if (email.value.isBlank()) {
+            _errorEmail.value = MESSAGE_ERROR_EMAIL_EMPTY
+            isValid = false
+        } else if (!emailMatcher.matches()) {
+            _errorEmail.value = MESSAGE_ERROR_EMAIL
+            isValid = false
+        }
+
+        if (confirmEmail.value.isBlank()) {
+            _errorConfirmEmail.value = MESSAGE_CONFIRM_EMAIL_EMPTY
+            isValid = false
+        } else if (email.value != confirmEmail.value) {
+            _errorConfirmEmail.value = MESSAGE_ERROR_CONFIRM_EMAIL
+            isValid = false
+        }
+
+        if (phone.value.isBlank()) {
+            _errorPhone.value = MESSAGE_ERROR_PHONE_EMPTY
+            isValid = false
+        } else if (phone.value.length < PHONE_NUMBER_LENGTH) {
+            _errorPhone.value = MESSAGE_ERROR_PHONE
+            isValid = false
+        }
+
+        return isValid
+    }
+
+    companion object {
+        const val REGEX_EMAIL = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\$"
+        const val MESSAGE_ERROR_EMAIL = "The email is not valid"
+        const val MESSAGE_ERROR_PHONE = "The phone number is not valid"
+        const val MESSAGE_ERROR_CONFIRM_EMAIL = "The emails do not match"
+        const val MESSAGE_ERROR_PHONE_EMPTY = "The phone number is not valid"
+        const val MESSAGE_CONFIRM_EMAIL_EMPTY = "The confirm email cannot be empty"
+        const val MESSAGE_ERROR_EMAIL_EMPTY = "The email cannot be empty"
+        const val PHONE_NUMBER_LENGTH = 10
+        const val EMPTY_STRING = ""
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,5 +3,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    alias { libs.plugins.kotlin.serialization } apply false
+    alias(libs.plugins.kotlin.serialization ) apply false
+    alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,9 @@ activityCompose = "1.10.1"
 composeBom = "2025.08.01"
 navigation3Version = "1.0.0-alpha08"
 kotlinSerialization = "1.7.3"
+daggerHiltVersion = "2.56.2"
+kspVersion = "2.2.10-2.0.2"
+hiltViewModel = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,10 +32,14 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3Version" }
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3Version" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinSerialization" }
+dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "daggerHiltVersion" }
+dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "daggerHiltVersion" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltViewModel" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHiltVersion" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }


### PR DESCRIPTION
This commit introduces ViewModels for the Login and Register screens, enabling state management and input validation. Hilt is integrated for dependency injection.

**New Additions:**
- `LoginViewModel.kt`: Manages state for the Login screen, including ID input and a "save session" switch. Includes basic ID validation.
- `RegisterViewModel.kt`: Manages state for the Register screen, handling email, confirm email, and phone number inputs. Implements validation for these fields (email format, email confirmation match, phone number length).
- `MainApplication.kt`: Application class annotated with `@HiltAndroidApp` to enable Hilt.

**Updates to Existing Screens and Components:**
- `LoginScreen.kt`:
    - Now accepts a `LoginViewModel` instance.
    - `TextInputUsername` updated to use `id` and `idError` from the ViewModel.
    - `TextInputPassword` removed.
    - `SwitchSaveSession` composable added to manage the "save session" preference via the ViewModel.
    - `ButtonLogin` now triggers validation in the ViewModel before navigating.
    - Login description text updated.
- `RegisterScreen.kt`:
    - Now accepts a `RegisterViewModel` instance.
    - `TextFieldEmailRegister`, `TextConfirmEmailRegister`, and `TextFieldPhoneRegister` (renamed from `TextFieldPasswordRegister`) now use state and error flows from the ViewModel.
    - `ButtonRegister` now triggers field validation in the ViewModel before navigating.
- `TextFieldCommon.kt`:
    - Added `isError`, `errorMessage`, and `keyboardOptions` parameters to support input validation and specific keyboard types.
- `Navigation.kt`:
    - Updated to use `hiltViewModel()` to provide ViewModel instances to `LoginScreen` and `RegisterScreen`.
- `MainActivity.kt`:
    - Annotated with `@AndroidEntryPoint` for Hilt integration.
- `AndroidManifest.xml`:
    - Updated to use `MainApplication`.

**Dependency Updates:**
- Added Hilt dependencies: `dagger-hilt-android`, `dagger-hilt-compiler`, `hilt-navigation-compose`.
- Added Hilt and KSP plugins to `build.gradle.kts` (project and app level).

**Key Changes in `TextFieldCommon`:**
- Now displays an error message below the text field when `isError` is true and `errorMessage` is provided.
- Accepts `KeyboardOptions` to customize the keyboard type (e.g., number, email).