### PR TITLE
Refactor: Organize data layer and update user data saving logic

### DIFF
--- a/app/src/main/java/com/example/launchcamera/data/datasource/MlKitOcrDatasource.kt
+++ b/app/src/main/java/com/example/launchcamera/data/datasource/MlKitOcrDatasource.kt
@@ -1,8 +1,8 @@
-package com.example.launchcamera.data.impl
+package com.example.launchcamera.data.datasource
 
 import android.annotation.SuppressLint
 import androidx.camera.core.ImageProxy
-import com.example.launchcamera.data.datasource.OcrDatasource
+import com.example.launchcamera.domain.repository.OcrDataRepository
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.Text
 import com.google.mlkit.vision.text.TextRecognition
@@ -13,7 +13,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 @SuppressLint("UnsafeOptInUsageError")
-class MlKitOcrDatasource @Inject constructor() : OcrDatasource {
+class MlKitOcrDatasource @Inject constructor() : OcrDataRepository {
 
     override suspend fun recognizeText(imageProxy: ImageProxy): Result<Text> = try {
         val recognizedText = processImageWithMlKit(imageProxy)

--- a/app/src/main/java/com/example/launchcamera/data/datasource/OcrRepositoryImpl.kt
+++ b/app/src/main/java/com/example/launchcamera/data/datasource/OcrRepositoryImpl.kt
@@ -1,13 +1,14 @@
-package com.example.launchcamera.domain.repository
+package com.example.launchcamera.data.datasource
 
 import androidx.camera.core.ImageProxy
-import com.example.launchcamera.data.datasource.OcrDatasource
 import com.example.launchcamera.domain.model.UserData
 import com.example.launchcamera.domain.parser.MLKitTextParser
+import com.example.launchcamera.domain.repository.OcrDataRepository
+import com.example.launchcamera.domain.repository.OcrRepository
 import javax.inject.Inject
 
 class OcrRepositoryImpl @Inject constructor(
-    private val ocrDatasource: OcrDatasource,
+    private val ocrDatasource: OcrDataRepository,
     private val mlKitTextParser: MLKitTextParser
 ): OcrRepository {
     override suspend fun extractTextFromImage(image: ImageProxy, data: UserData): Result<UserData> =

--- a/app/src/main/java/com/example/launchcamera/data/datasource/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/launchcamera/data/datasource/UserRepositoryImpl.kt
@@ -1,8 +1,9 @@
-package com.example.launchcamera.domain.repository
+package com.example.launchcamera.data.datasource
 
 import com.example.launchcamera.data.datasource.dao.UserDao
 import com.example.launchcamera.data.model.UserDataEntity
 import com.example.launchcamera.domain.model.UserData
+import com.example.launchcamera.domain.repository.UserRepository
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(

--- a/app/src/main/java/com/example/launchcamera/data/di/DataModule.kt
+++ b/app/src/main/java/com/example/launchcamera/data/di/DataModule.kt
@@ -1,7 +1,7 @@
 package com.example.launchcamera.data.di
 
-import com.example.launchcamera.data.datasource.OcrDatasource
-import com.example.launchcamera.data.impl.MlKitOcrDatasource
+import com.example.launchcamera.domain.repository.OcrDataRepository
+import com.example.launchcamera.data.datasource.MlKitOcrDatasource
 import com.example.launchcamera.data.parser.ExtractedDataValidatorImpl
 import com.example.launchcamera.data.parser.IdentityCardExtractor
 import com.example.launchcamera.data.parser.MLKitTextParserImpl
@@ -26,7 +26,7 @@ abstract class DataModule {
     @Singleton
     abstract fun bindOcrDatasource(
         mlKitOcrDatasource: MlKitOcrDatasource
-    ) : OcrDatasource
+    ) : OcrDataRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/example/launchcamera/domain/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/launchcamera/domain/di/RepositoryModule.kt
@@ -1,9 +1,9 @@
 package com.example.launchcamera.domain.di
 
 import com.example.launchcamera.domain.repository.OcrRepository
-import com.example.launchcamera.domain.repository.OcrRepositoryImpl
+import com.example.launchcamera.data.datasource.OcrRepositoryImpl
 import com.example.launchcamera.domain.repository.UserRepository
-import com.example.launchcamera.domain.repository.UserRepositoryImpl
+import com.example.launchcamera.data.datasource.UserRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/app/src/main/java/com/example/launchcamera/domain/repository/OcrDataRepository.kt
+++ b/app/src/main/java/com/example/launchcamera/domain/repository/OcrDataRepository.kt
@@ -1,8 +1,8 @@
-package com.example.launchcamera.data.datasource
+package com.example.launchcamera.domain.repository
 
 import androidx.camera.core.ImageProxy
 import com.google.mlkit.vision.text.Text
 
-interface OcrDatasource {
+interface OcrDataRepository {
     suspend fun recognizeText(imageProxy: ImageProxy): Result<Text>
 }

--- a/app/src/main/java/com/example/launchcamera/screen/camera/viewModel/CameraScannerViewModel.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/camera/viewModel/CameraScannerViewModel.kt
@@ -92,7 +92,6 @@ class CameraScannerViewModel @Inject constructor(
             result.getOrNull()?.let { newUserData ->
                 updateUserData(newUserData)
                 updateScanStateBasedOnUserData(newUserData)
-                saveUser(newUserData)
             }
             isProgress = false
         } else {
@@ -107,6 +106,7 @@ class CameraScannerViewModel @Inject constructor(
 
     private fun updateScanStateBasedOnUserData(userData: UserData) {
         val newScanState = if (userDataValidator.isUserDataComplete(userData)) {
+            saveUser(userData)
             ScanState.FINISH
         } else {
             ScanState.BACK_SIDE


### PR DESCRIPTION
This commit reorganizes the data layer by moving repository implementations to the `data.datasource` package and renames `OcrDatasource` to `OcrDataRepository` for clarity. It also updates the `CameraScannerViewModel` to save user data only when the scan state is `FINISH`.

Key changes:

-   **Package Restructuring**:
    -   `MlKitOcrDatasource.kt`: Moved from `data.impl` to `data.datasource`. The interface it implements, formerly `OcrDatasource`, has been renamed to `OcrDataRepository` and moved to `domain.repository`.
    -   `OcrRepositoryImpl.kt`: Moved from `domain.repository` to `data.datasource`. It now depends on `OcrDataRepository`.
    -   `UserRepositoryImpl.kt`: Moved from `domain.repository` to `data.datasource`.
-   **DI Module Updates**:
    -   `DataModule.kt`: Updated `bindOcrDatasource` to bind `MlKitOcrDatasource` to the renamed `OcrDataRepository` interface.
    -   `RepositoryModule.kt`: Updated to bind `OcrRepositoryImpl` and `UserRepositoryImpl` from their new locations in `data.datasource`.
-   **User Data Saving Logic**:
    -   `CameraScannerViewModel.kt`: The `saveUser(newUserData)` call has been moved from the `processImage` success block to the `updateScanStateBasedOnUserData` function. Now, user data is saved only when `userDataValidator.isUserDataComplete(userData)` is true, which corresponds to the `ScanState.FINISH`.