### PR TITLE
Refactor en LoginViewModel, RegisterViewModel y agregado de pruebas unitarias para UpdateUserUseCase y ProfileViewModel

### DIFF
--- a/app/src/main/java/com/example/launchcamera/domain/usescases/UpdateUserUseCase.kt
+++ b/app/src/main/java/com/example/launchcamera/domain/usescases/UpdateUserUseCase.kt
@@ -1,6 +1,5 @@
 package com.example.launchcamera.domain.usescases
 
-import com.example.launchcamera.domain.model.UserData
 import com.example.launchcamera.domain.repository.UserRepository
 import javax.inject.Inject
 

--- a/app/src/main/java/com/example/launchcamera/screen/login/viewModel/LoginVewModel.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/login/viewModel/LoginVewModel.kt
@@ -30,6 +30,10 @@ class LoginViewModel @Inject constructor(
 
     fun onIdChanged(newId: String) {
         _id.update { newId }
+        if (newId.isNotBlank()) {
+            _idError.value = null
+        }
+
     }
 
     fun onSaveSessionChanged(save: Boolean) {

--- a/app/src/main/java/com/example/launchcamera/screen/register/viewModel/RegisterViewModel.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/register/viewModel/RegisterViewModel.kt
@@ -119,7 +119,7 @@ class RegisterViewModel @Inject constructor(
         }
     }
 
-    companion object {
+    internal companion object {
         const val REGEX_EMAIL = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\$"
         const val MESSAGE_ERROR_EMAIL = "The email is not valid"
         const val MESSAGE_ERROR_PHONE = "The phone number is not valid"

--- a/app/src/main/java/com/example/launchcamera/screen/register/viewModel/RegisterViewModel.kt
+++ b/app/src/main/java/com/example/launchcamera/screen/register/viewModel/RegisterViewModel.kt
@@ -22,7 +22,7 @@ class RegisterViewModel @Inject constructor(
 ) : ViewModel() {
 
     val userName = savedStateHandle.get<String>(USER_NAME_ARGUMENT)
-    private var userId = savedStateHandle.get<String>(USER_ID_ARGUMENT)
+    internal var userId = savedStateHandle.get<String>(USER_ID_ARGUMENT)
 
     private val _registryState = MutableStateFlow<ScreenState>(ScreenState.Idle)
     val registryState = _registryState.asStateFlow()
@@ -110,7 +110,7 @@ class RegisterViewModel @Inject constructor(
                 _email.value,
                 _phone.value
             )
-            if (result.isSuccess) {
+            if (result.isSuccess && result.getOrNull() == true) {
                 _registryState.value = ScreenState.Success
             } else {
                 _registryState.value = ScreenState.Error

--- a/app/src/test/java/com/example/launchcamera/domain/usecase/UpdateUserUseCaseTest.kt
+++ b/app/src/test/java/com/example/launchcamera/domain/usecase/UpdateUserUseCaseTest.kt
@@ -1,0 +1,120 @@
+package com.example.launchcamera.domain.usecase
+
+import com.example.launchcamera.domain.repository.UserRepository
+import com.example.launchcamera.domain.usescases.UpdateUserUseCase
+import com.example.launchcamera.mock.TypeMockSimulator
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class UpdateUserUseCaseTest {
+
+    @Test
+    fun `When the use case is called to update the user data and the id exists in the database then it returns the correct data`() =
+        runTest {
+            // Given
+            val userRepository = providesUserRepository(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userRepository)
+            // When
+            val result = sut.invoke(USER_ID_TEST, EMAIL_VALUE_TEST, PHONE_NUMBER_TEST)
+            // Then
+            coVerify(exactly = 1) {
+                userRepository.updateUser(
+                    USER_ID_TEST,
+                    EMAIL_VALUE_TEST,
+                    PHONE_NUMBER_TEST
+                )
+            }
+            assertTrue(result.isSuccess)
+            assertEquals(EXPECTED_RESULT_TRUE, result.getOrNull())
+        }
+
+    @Test
+    fun `When the use case is called and the repository returns an error then it returns a failure result`() =
+        runTest {
+            // Given
+            val userRepository = providesUserRepository(TypeMockSimulator.ERROR)
+            val sut = providesSut(userRepository)
+            // When
+            val result = sut.invoke(USER_ID_TEST, EMAIL_VALUE_TEST, PHONE_NUMBER_TEST)
+            // Then
+            coVerify(exactly = 1) {
+                userRepository.updateUser(
+                    any(),
+                    any(),
+                    any()
+                )
+            }
+            assertTrue(result.isFailure)
+            assertEquals(EXPECTED_EXCEPTION_MESSAGE, result.exceptionOrNull()?.message)
+        }
+
+    @Test
+    fun `When the use case is called and the user id does not exist then it returns a success result with null data`() =
+        runTest {
+            // Given
+            val userRepository = providesUserRepository(TypeMockSimulator.NULL)
+            val sut = providesSut(userRepository)
+            // When
+            val result = sut.invoke(USER_ID_TEST, EMAIL_VALUE_TEST, PHONE_NUMBER_TEST)
+            // Then
+            coVerify(exactly = 1) {
+                userRepository.updateUser(
+                    any(),
+                    any(),
+                    any()
+                )
+            }
+            assertTrue(result.isSuccess)
+            assertEquals(EXPECTED_RESULT_FALSE, result.getOrNull())
+        }
+
+    @Test
+    fun `When the use case is called and the repository returns empty user data then it returns a success result with empty UserData`() =
+        runTest {
+            // Given
+            val userRepository = providesUserRepository(TypeMockSimulator.EMPTY)
+            val sut = providesSut(userRepository)
+            // When
+            val result = sut.invoke(USER_ID_TEST, EMAIL_VALUE_TEST, PHONE_NUMBER_TEST)
+            // Then
+            assertTrue(result.isSuccess)
+            assertEquals(EXPECTED_RESULT_TRUE, result.getOrNull())
+
+        }
+
+    private fun providesSut(userRepository: UserRepository) = UpdateUserUseCase(userRepository)
+
+    private fun providesUserRepository(type: TypeMockSimulator) = mockk<UserRepository>() {
+        when (type) {
+            TypeMockSimulator.SUCCESS -> coEvery {
+                updateUser(USER_ID_TEST, EMAIL_VALUE_TEST, PHONE_NUMBER_TEST)
+            } returns Result.success(true)
+
+            TypeMockSimulator.ERROR -> coEvery {
+                updateUser(any(), any(), any())
+            } returns Result.failure(Exception(EXPECTED_EXCEPTION_MESSAGE))
+
+            TypeMockSimulator.NULL -> coEvery {
+                updateUser(any(), any(), any())
+            } returns Result.success(false)
+
+            TypeMockSimulator.EMPTY -> coEvery {
+                updateUser(any(), any(), any())
+            } returns Result.success(true)
+        }
+    }
+
+    companion object {
+        private const val PHONE_NUMBER_TEST = "3110000000"
+        private const val EMAIL_VALUE_TEST = "test@user.com"
+        private const val USER_ID_TEST = "1234567"
+        private const val EXPECTED_EXCEPTION_MESSAGE = "Database error"
+        private const val EXPECTED_RESULT_TRUE = true
+        private const val EXPECTED_RESULT_FALSE = false
+    }
+}

--- a/app/src/test/java/com/example/launchcamera/screen/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/example/launchcamera/screen/profile/ProfileViewModelTest.kt
@@ -1,0 +1,121 @@
+package com.example.launchcamera.screen.profile
+
+import androidx.lifecycle.SavedStateHandle
+import com.example.launchcamera.MainCoroutineRule
+import com.example.launchcamera.domain.model.UserData
+import com.example.launchcamera.domain.usescases.GetUserByIdUseCase
+import com.example.launchcamera.mock.TypeMockSimulator
+import com.example.launchcamera.mock.data.getUserDataMockk
+import com.example.launchcamera.screen.profile.viewModel.ProfileViewModel
+import com.example.launchcamera.screen.state.ScreenState
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileViewModelTest {
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    @Test
+    fun `When getUserById is called and the id exists in the database then it returns the correct data`() =
+        runTest {
+            // Given
+            val getUserByIdUseCase = providesGetUserByIdUseCase(TypeMockSimulator.SUCCESS)
+            val saveStateHandle = providesSaveStateHandle()
+            val sut = providesSut(getUserByIdUseCase, saveStateHandle)
+            // When
+            sut.getUserById(USER_ID_TEST)
+            // Then
+            coVerify(exactly = 1) { getUserByIdUseCase.invoke(USER_ID_TEST) }
+            assertEquals(ScreenState.Success, sut.stateProfile.value)
+            assertEquals(getUserDataMockk(), sut.userData.value)
+        }
+
+    @Test
+    fun `When getUserById is called and the repository returns an error then it returns a failure result`() =
+        runTest {
+            // Given
+            val getUserByIdUseCase = providesGetUserByIdUseCase(TypeMockSimulator.ERROR)
+            val saveStateHandle = providesSaveStateHandle()
+            val sut = providesSut(getUserByIdUseCase, saveStateHandle)
+            // When
+            sut.getUserById(USER_ID_TEST)
+            // Then
+            coVerify(exactly = 1) { getUserByIdUseCase.invoke(USER_ID_TEST) }
+            assertEquals(ScreenState.Error, sut.stateProfile.value)
+            assertEquals(EXPECTED_EXCEPTION_MESSAGE, sut.messageError.value)
+        }
+
+    @Test
+    fun `When getUserById is called and the user id does not exist then it returns a success result with null data`() =
+        runTest {
+            // Given
+            val getUserByIdUseCase = providesGetUserByIdUseCase(TypeMockSimulator.NULL)
+            val saveStateHandle = providesSaveStateHandle()
+            val sut = providesSut(getUserByIdUseCase, saveStateHandle)
+            // When
+            sut.getUserById(USER_ID_TEST)
+            // Then
+            coVerify(exactly = 1) { getUserByIdUseCase.invoke(USER_ID_TEST) }
+            assertEquals(ScreenState.Success, sut.stateProfile.value)
+            assertEquals(null, sut.userData.value)
+        }
+
+    @Test
+    fun `When getUserById is called and the repository returns empty user data then it returns a success result with empty UserData`() =
+        runTest {
+            // Give
+            val getUserByIdUseCase = providesGetUserByIdUseCase(TypeMockSimulator.EMPTY)
+            val saveStateHandle = providesSaveStateHandle()
+            val sut = providesSut(getUserByIdUseCase, saveStateHandle)
+            // When
+            sut.getUserById(USER_ID_TEST)
+            // Then
+            coVerify(exactly = 1) { getUserByIdUseCase.invoke(USER_ID_TEST) }
+            assertEquals(ScreenState.Success, sut.stateProfile.value)
+            assertEquals(UserData(), sut.userData.value)
+        }
+
+
+    private fun providesSut(
+        getUserByIdUseCase: GetUserByIdUseCase,
+        handle: SavedStateHandle
+    ) = ProfileViewModel(getUserByIdUseCase, handle)
+
+    private fun providesGetUserByIdUseCase(type: TypeMockSimulator) =
+        mockk<GetUserByIdUseCase>().also {
+            when (type) {
+                TypeMockSimulator.SUCCESS -> coEvery {
+                    it.invoke(any())
+                } returns Result.success(
+                    getUserDataMockk()
+                )
+
+                TypeMockSimulator.ERROR -> coEvery { it.invoke(any()) } returns Result.failure(
+                    Exception(EXPECTED_EXCEPTION_MESSAGE)
+                )
+
+                TypeMockSimulator.NULL -> coEvery { it.invoke(any()) } returns Result.success(null)
+                TypeMockSimulator.EMPTY -> coEvery { it.invoke(any()) } returns Result.success(
+                    UserData()
+                )
+            }
+        }
+
+    private fun providesSaveStateHandle() = mockk<SavedStateHandle>().also {
+        every { it.get<String>(any()) } returns USER_ID_TEST
+    }
+
+    companion object {
+        private const val USER_ID_TEST = "1234567"
+        private const val EXPECTED_EXCEPTION_MESSAGE = "Database error"
+    }
+}

--- a/app/src/test/java/com/example/launchcamera/screen/register/viewmodel/RegisterViewModelTest.kt
+++ b/app/src/test/java/com/example/launchcamera/screen/register/viewmodel/RegisterViewModelTest.kt
@@ -1,0 +1,230 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.example.launchcamera.screen.register.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import com.example.launchcamera.MainCoroutineRule
+import com.example.launchcamera.domain.usescases.UpdateUserUseCase
+import com.example.launchcamera.mock.TypeMockSimulator
+import com.example.launchcamera.screen.register.viewModel.RegisterViewModel
+import com.example.launchcamera.screen.register.viewModel.RegisterViewModel.Companion.EMPTY_STRING
+import com.example.launchcamera.screen.register.viewModel.RegisterViewModel.Companion.MESSAGE_CONFIRM_EMAIL_EMPTY
+import com.example.launchcamera.screen.register.viewModel.RegisterViewModel.Companion.MESSAGE_ERROR_CONFIRM_EMAIL
+import com.example.launchcamera.screen.register.viewModel.RegisterViewModel.Companion.MESSAGE_ERROR_EMAIL
+import com.example.launchcamera.screen.register.viewModel.RegisterViewModel.Companion.MESSAGE_ERROR_EMAIL_EMPTY
+import com.example.launchcamera.screen.register.viewModel.RegisterViewModel.Companion.MESSAGE_ERROR_PHONE
+import com.example.launchcamera.screen.register.viewModel.RegisterViewModel.Companion.MESSAGE_ERROR_PHONE_EMPTY
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class RegisterViewModelTest {
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    @Test
+    fun `when onEmailChanged is called with a new email, email state should be updated`() =
+        runTest {
+            // Given
+
+            val saveStateHandle = providesSaveStateHandle()
+            val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userUseCase, saveStateHandle)
+            // When
+            sut.onEmailChanged(EMAIL_VALUE_TEST)
+            val result = sut.validateFields()
+            // Then
+            assertEquals(EMAIL_VALUE_TEST, sut.email.value)
+            assertEquals(null, sut.errorEmail.value)
+        }
+
+    @Test
+    fun `when onEmailChanged is called with a new email, email state is nor valid should be updated`() =
+        runTest {
+            // Given
+            val email = "email"
+            val saveStateHandle = providesSaveStateHandle()
+            val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userUseCase, saveStateHandle)
+            // When
+            sut.onEmailChanged(email)
+            val result = sut.validateFields()
+            // Then
+            assertEquals(email, sut.email.value)
+            assertEquals(MESSAGE_ERROR_EMAIL, sut.errorEmail.value)
+            assertFalse(result)
+        }
+
+    @Test
+    fun `When onConfirmEmailChanged is called with a new email, the email status is empty and needs to be updated`() =
+        runTest {
+            // Given
+            val saveStateHandle = providesSaveStateHandle()
+            val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userUseCase, saveStateHandle)
+            // When
+            sut.onEmailChanged(EMPTY_STRING)
+            val result = sut.validateFields()
+            // Then
+            assertEquals(EMPTY_STRING, sut.email.value)
+            assertEquals(MESSAGE_ERROR_EMAIL_EMPTY, sut.errorEmail.value)
+            assertFalse(result)
+        }
+
+    @Test
+    fun `when onConfirmEmailChanged is called with a new email, confirmEmail state should be updated`() =
+        runTest {
+            val saveStateHandle = providesSaveStateHandle()
+            val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userUseCase, saveStateHandle)
+            // When
+            sut.onEmailChanged(EMAIL_VALUE_TEST)
+            sut.onConfirmEmailChanged(EMAIL_VALUE_TEST)
+            val result = sut.validateFields()
+            // Then
+            assertEquals(EMAIL_VALUE_TEST, sut.confirmEmail.value)
+            assertEquals(EMAIL_VALUE_TEST, sut.email.value)
+            assertEquals(null, sut.errorConfirmEmail.value)
+        }
+
+    @Test
+    fun `When onConfirmEmailChanged is called but the value is different from the email then it returns an error message`() =
+        runTest {
+            val emailExpected = "email"
+            val saveStateHandle = providesSaveStateHandle()
+            val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userUseCase, saveStateHandle)
+            // When
+            sut.onEmailChanged(EMAIL_VALUE_TEST)
+            sut.onConfirmEmailChanged(emailExpected)
+            val result = sut.validateFields()
+            // Then
+            assertEquals(emailExpected, sut.confirmEmail.value)
+            assertEquals(MESSAGE_ERROR_CONFIRM_EMAIL, sut.errorConfirmEmail.value)
+            assertFalse(result)
+        }
+
+    @Test
+    fun `When onConfirmEmailChanged is called but the value is empty, then it returns an error message`() =
+        runTest {
+            val saveStateHandle = providesSaveStateHandle()
+            val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userUseCase, saveStateHandle)
+            // When
+            sut.onConfirmEmailChanged(EMPTY_STRING)
+            val result = sut.validateFields()
+            // Then
+            assertEquals(EMPTY_STRING, sut.confirmEmail.value)
+            assertEquals(MESSAGE_CONFIRM_EMAIL_EMPTY, sut.errorConfirmEmail.value)
+            assertFalse(result)
+        }
+
+    @Test
+    fun `when onPhoneChanged is called with a new phone, phone state should be updated`() =
+        runTest {
+            // Given
+            val saveStateHandle = providesSaveStateHandle()
+            val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userUseCase, saveStateHandle)
+            // When
+            sut.onPhoneChanged(PHONE_NUMBER_TEST)
+            // Then
+            assertEquals(PHONE_NUMBER_TEST, sut.phone.value)
+            assertEquals(null, sut.errorPhone.value)
+        }
+
+    @Test
+    fun `when onPhoneChanged is called with a new phone, phone state is nor valid should be updated`() =
+        runTest {
+            // Given
+            val saveStateHandle = providesSaveStateHandle()
+            val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userUseCase, saveStateHandle)
+            // When
+            sut.onPhoneChanged(EMPTY_STRING)
+            val result = sut.validateFields()
+            // Then
+            assertEquals(EMPTY_STRING, sut.phone.value)
+            assertEquals(MESSAGE_ERROR_PHONE_EMPTY, sut.errorPhone.value)
+            assertFalse(result)
+        }
+
+    @Test
+    fun `when onPhoneChanged is called with a new phone, phone state is not valid should be updated`() =
+        runTest {
+            // Given
+            val phone = "123456789"
+            val saveStateHandle = providesSaveStateHandle()
+            val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+            val sut = providesSut(userUseCase, saveStateHandle)
+            // When
+            sut.onPhoneChanged(phone)
+            val result = sut.validateFields()
+            // Then
+            assertEquals(phone, sut.phone.value)
+            assertEquals(MESSAGE_ERROR_PHONE, sut.errorPhone.value)
+            assertFalse(result)
+        }
+
+    @Test
+    fun `When all validated fields are correct then it returns true`() = runTest {
+        // Given
+        val saveStateHandle = providesSaveStateHandle()
+        val userUseCase = providesUserUseCase(TypeMockSimulator.SUCCESS)
+        val sut = providesSut(userUseCase, saveStateHandle)
+        // Given
+        sut.onEmailChanged(EMAIL_VALUE_TEST)
+        sut.onConfirmEmailChanged(EMAIL_VALUE_TEST)
+        sut.onPhoneChanged(PHONE_NUMBER_TEST)
+        val result = sut.validateFields()
+        // Then
+        assertTrue(result)
+    }
+
+    private fun providesSut(
+        userUseCase: UpdateUserUseCase,
+        handle: SavedStateHandle
+    ) = RegisterViewModel(
+        savedStateHandle = handle,
+        updateUserUseCase = userUseCase
+    )
+
+    private fun providesSaveStateHandle() = mockk<SavedStateHandle>().also {
+        every { it.get<String>(any()) } returns USER_ID_TEST
+    }
+
+    private fun providesUserUseCase(type: TypeMockSimulator) = mockk<UpdateUserUseCase>().also {
+        when (type) {
+            TypeMockSimulator.SUCCESS -> coEvery {
+                it.invoke(any(), any(), any())
+            } returns Result.success(true)
+
+            TypeMockSimulator.ERROR -> coEvery {
+                it.invoke(any(), any(), any())
+            } returns Result.failure(Exception(EXPECTED_EXCEPTION_MESSAGE))
+
+            TypeMockSimulator.NULL -> coEvery {
+                it.invoke(any(), any(), any())
+            } returns Result.success(false)
+
+            TypeMockSimulator.EMPTY -> coEvery {
+                it.invoke(any(), any(), any())
+            } returns Result.success(true)
+        }
+    }
+
+    companion object {
+        private const val PHONE_NUMBER_TEST = "3110000000"
+        private const val EMAIL_VALUE_TEST = "test@user.com"
+        private const val USER_ID_TEST = "1234567"
+        private const val EXPECTED_EXCEPTION_MESSAGE = "Database error"
+    }
+}


### PR DESCRIPTION
## Descripción

Este PR incluye los siguientes cambios:

LoginViewModel: se ajusta la validación del campo id, limpiando errores cuando el valor no está en blanco.

RegisterViewModel:

Cambio de visibilidad de userId a internal para mejorar testabilidad.

Validación más estricta al registrar usuario (isSuccess && result.getOrNull() == true).

El companion object se declara como internal para limitar su exposición.

UpdateUserUseCase: eliminación de import no utilizado (UserData).

Tests agregados:

UpdateUserUseCaseTest: validaciones de éxito, error, datos nulos y datos vacíos.

ProfileViewModelTest: validación de flujos al obtener usuario por id.

RegisterViewModelTest: validación de campos (email, confirmEmail, phone) y actualización de usuario en diferentes escenarios.

Estos cambios mejoran la robustez de la lógica de negocio, la testabilidad de las viewmodels y la cobertura de pruebas unitarias en el dominio y capa de presentación.

## Casos de test cubiertos
✅ UpdateUserUseCaseTest

Cuando el usuario existe y se actualiza correctamente, retorna éxito con true.

Cuando el repositorio retorna error, retorna Result.failure con mensaje esperado.

Cuando el id no existe, retorna Result.success(false).

Cuando el repositorio retorna datos vacíos, retorna Result.success(true).

✅ ProfileViewModelTest

getUserById retorna datos correctos cuando el id existe.

getUserById retorna error cuando el repositorio falla.

getUserById retorna null cuando el id no existe.

getUserById retorna UserData vacío cuando el repositorio no tiene información.

✅ RegisterViewModelTest

Validación de email correcto e incorrecto.

Validación de email vacío.

Validación de confirmación de email correcto, distinto y vacío.

Validación de teléfono correcto, incorrecto y vacío.

Validación de todos los campos correctos retorna true.

Actualización de usuario exitosa cambia el estado a Success.

Error en la actualización cambia el estado a Error con mensaje.

Usuario no encontrado retorna estado Error.